### PR TITLE
Return ErrNotCapable when bsv capability lookup fails.

### DIFF
--- a/bsvalias/site_test.go
+++ b/bsvalias/site_test.go
@@ -1,0 +1,68 @@
+package bsvalias
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestGetSite(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		domain  string
+		wantErr error
+		wantURL string
+	}{
+		{
+			name:    "moneybutton.com",
+			domain:  "moneybutton.com",
+			wantURL: "https://www.moneybutton.com",
+		},
+		{
+			name:    "polynym.io",
+			domain:  "polynym.io",
+			wantURL: "https://api.polynym.io",
+		},
+		{
+			name:    "handcash.io",
+			domain:  "handcash.io",
+			wantURL: "https://cloud.handcash.io",
+		},
+		{
+			name:    "tokenized.id",
+			domain:  "tokenized.id",
+			wantURL: "https://nexus-api.tokenized.com",
+		},
+		{
+			name:    "example.com",
+			domain:  "example.com",
+			wantErr: ErrNotCapable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			site, err := GetSite(ctx, tt.domain)
+
+			if tt.wantErr != nil {
+				if errors.Cause(err) != tt.wantErr {
+					t.Fatalf("got err %v, want %v", err, tt.wantErr)
+				}
+
+				// success
+				return
+			}
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if site.URL != tt.wantURL {
+				t.Errorf("got %q want %q", site.URL, tt.wantURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Also omits the port from the lookup when port is 443, which is default for SSL anyway.